### PR TITLE
refactor: standardize Waveshare LCD function names

### DIFF
--- a/components/rgb_lcd_port/rgb_lcd_port.c
+++ b/components/rgb_lcd_port/rgb_lcd_port.c
@@ -131,7 +131,7 @@ esp_lcd_panel_handle_t waveshare_esp32_s3_rgb_lcd_init(void)
  * @param Yend   Ending Y coordinate (exclusive, absolute).
  * @param Image  Pointer to the image data buffer for full LCD resolution.
  */
-void wavesahre_rgb_lcd_display_window(int16_t Xstart, int16_t Ystart,
+void waveshare_rgb_lcd_display_window(int16_t Xstart, int16_t Ystart,
                                       int16_t Xend, int16_t Yend, uint8_t *Image)
 {
     if (Xstart < 0) Xstart = 0;
@@ -164,7 +164,7 @@ void wavesahre_rgb_lcd_display_window(int16_t Xstart, int16_t Ystart,
 /**
  * @brief Display a full-screen image on the RGB LCD.
  */
-void wavesahre_rgb_lcd_display(uint8_t *Image)
+void waveshare_rgb_lcd_display(uint8_t *Image)
 {
     esp_lcd_panel_draw_bitmap(panel_handle, 0, 0, EXAMPLE_LCD_H_RES, EXAMPLE_LCD_V_RES, Image);
 }
@@ -174,7 +174,7 @@ void waveshare_get_frame_buffer(void **buf1, void **buf2)
     ESP_ERROR_CHECK(esp_lcd_rgb_panel_get_frame_buffer(panel_handle, 2, buf1, buf2));
 }
 
-void waveahre_rgb_lcd_set_pclk(uint32_t freq_hz)
+void waveshare_rgb_lcd_set_pclk(uint32_t freq_hz)
 {
     esp_lcd_rgb_panel_set_pclk(panel_handle, freq_hz);
 }
@@ -187,7 +187,7 @@ void waveshare_rgb_lcd_restart(void)
 /**
  * @brief Turn on the RGB LCD screen backlight.
  */
-void wavesahre_rgb_lcd_bl_on(void)
+void waveshare_rgb_lcd_bl_on(void)
 {
     IO_EXTENSION_Output(IO_EXTENSION_IO_2, 1);
 }
@@ -195,7 +195,7 @@ void wavesahre_rgb_lcd_bl_on(void)
 /**
  * @brief Turn off the RGB LCD screen backlight.
  */
-void wavesahre_rgb_lcd_bl_off(void)
+void waveshare_rgb_lcd_bl_off(void)
 {
     IO_EXTENSION_Output(IO_EXTENSION_IO_2, 0);
 }

--- a/components/rgb_lcd_port/rgb_lcd_port.h
+++ b/components/rgb_lcd_port/rgb_lcd_port.h
@@ -91,27 +91,26 @@
 esp_lcd_panel_handle_t waveshare_esp32_s3_rgb_lcd_init(void);
 
 /** Turn on the LCD backlight. */
-void wavesahre_rgb_lcd_bl_on(void);
+void waveshare_rgb_lcd_bl_on(void);
 
 /** Turn off the LCD backlight. */
-void wavesahre_rgb_lcd_bl_off(void);
+void waveshare_rgb_lcd_bl_off(void);
 
 /**
  * @brief Display a rectangular region of an image on the RGB LCD.
  */
-void wavesahre_rgb_lcd_display_window(int16_t Xstart, int16_t Ystart, int16_t Xend, int16_t Yend, uint8_t *Image);
+void waveshare_rgb_lcd_display_window(int16_t Xstart, int16_t Ystart, int16_t Xend, int16_t Yend, uint8_t *Image);
 
 /**
  * @brief Display a full-frame image on the RGB LCD.
  */
-void wavesahre_rgb_lcd_display(uint8_t *Image);
+void waveshare_rgb_lcd_display(uint8_t *Image);
 
 /**
  * @brief Retrieve pointers to the frame buffers for double buffering.
  */
 void waveshare_get_frame_buffer(void **buf1, void **buf2);
-
-void waveahre_rgb_lcd_set_pclk(uint32_t freq_hz);
+void waveshare_rgb_lcd_set_pclk(uint32_t freq_hz);
 void waveshare_rgb_lcd_restart(void);
 
 #endif // _RGB_LCD_H_

--- a/main/main.c
+++ b/main/main.c
@@ -59,7 +59,7 @@ void app_main()
 
     // Turn on the LCD backlight
     // This ensures the display is visible.
-    wavesahre_rgb_lcd_bl_on();
+    waveshare_rgb_lcd_bl_on();
 
     // Initialize the LVGL library, linking it to the LCD and touch panel handles
     // LVGL is a lightweight graphics library used for rendering UI elements.

--- a/main/user/wifi/wifi.c
+++ b/main/user/wifi/wifi.c
@@ -113,10 +113,10 @@ void wifi_task(void *arg)
         if (WIFI_STA_FLAG)
         {
             WIFI_STA_FLAG = false;
-            waveahre_rgb_lcd_set_pclk(12 * 1000 * 1000);  // Set pixel clock for the LCD
+            waveshare_rgb_lcd_set_pclk(12 * 1000 * 1000);  // Set pixel clock for the LCD
             vTaskDelay(20);  // Delay for a short while
             wifi_sta_init(ap_info[wifi_index].ssid, wifi_pwd, ap_info[wifi_index].authmode);  // Initialize Wi-Fi as STA and connect
-            waveahre_rgb_lcd_set_pclk(EXAMPLE_LCD_PIXEL_CLOCK_HZ);  // Restore original pixel clock
+            waveshare_rgb_lcd_set_pclk(EXAMPLE_LCD_PIXEL_CLOCK_HZ);  // Restore original pixel clock
             lv_timer_t *t = lv_timer_create(wifi_connection_cb, 100, NULL);  // Update UI every 100ms
             lv_timer_set_repeat_count(t, 1);  // Run only once
         }

--- a/main/user/wifi/wifi_ap.c
+++ b/main/user/wifi/wifi_ap.c
@@ -77,12 +77,12 @@ void wifi_open_ap()
             ESP_ERROR_CHECK(esp_wifi_start());
             
             // Adjust the pixel clock for the display
-            waveahre_rgb_lcd_set_pclk(12 * 1000 * 1000);
+            waveshare_rgb_lcd_set_pclk(12 * 1000 * 1000);
             vTaskDelay(20);
             ESP_ERROR_CHECK(esp_wifi_connect()); // Reconnect to the Wi-Fi network
             connection_last_flag = true;
             wifi_wait_connect();
-            waveahre_rgb_lcd_set_pclk(EXAMPLE_LCD_PIXEL_CLOCK_HZ);
+            waveshare_rgb_lcd_set_pclk(EXAMPLE_LCD_PIXEL_CLOCK_HZ);
         } 
     }
     else


### PR DESCRIPTION
## Summary
- rename mis-typed `waveahre`/`wavesahre` functions to `waveshare`
- update Wi-Fi modules and main application to use new Waveshare LCD API

## Testing
- `bash scripts/checks.sh` *(fails: No such file or directory)*
- `make build` *(fails: cannot open /export.sh: No such file)*

------
https://chatgpt.com/codex/tasks/task_e_689c3c5f7f308323941b6b53641c82c8