### PR TITLE
rs485/can: replace strncat with bounded operations

### DIFF
--- a/main/user/can/can.c
+++ b/main/user/can/can.c
@@ -72,7 +72,7 @@ void can_task(void* arg) {
       snprintf(message_str + strlen(message_str), sizeof(message_str) - strlen(message_str), "\n");
 
       // Append the formatted message to the global CAN data buffer
-      strncat(can_data, message_str, sizeof(can_data) - strlen(can_data) - 1);
+      strlcat(can_data, message_str, sizeof(can_data));
 
       // Create a timer to update the textarea every 100ms
       lv_timer_t* t = lv_timer_create(can_update_textarea_cb, 100, NULL);

--- a/main/user/rs485/rs485.c
+++ b/main/user/rs485/rs485.c
@@ -1,12 +1,16 @@
-#include "ui.h"
-#include "rs485.h"
+#include <string.h>
 
-static const char *TAG = "RS485";  // Tag used for ESP log output
+#include "rs485.h"
+#include "ui.h"
+
+static const char* TAG = "RS485"; // Tag used for ESP log output
 
 TaskHandle_t rs485_TaskHandle;
 
+#define RS485_TEMP_BUF_SIZE 256 // Maximum temporary buffer size
+
 // Allocate a buffer to store incoming UART data
-static char data[BUF_SIZE] = {0};  // Buffer for receiving data
+static char data[BUF_SIZE] = {0}; // Buffer for receiving data
 
 /**
  * @brief Callback function to update the text area with the received data.
@@ -18,16 +22,15 @@ static char data[BUF_SIZE] = {0};  // Buffer for receiving data
  * @param timer Pointer to the lv_timer_t structure.
  * @return None
  */
-void rs485_update_textarea_cb(lv_timer_t *timer) {
-    // If the RS485_Clear flag is set, clear the data buffer
-    if (RS485_Clear)
-    {
-        memset(data, 0, sizeof(data));  // Clear the data buffer
-        RS485_Clear = false;  // Reset the flag
-    }
-    
-    // Update the text area with the received data
-    lv_textarea_set_text(ui_RS485_Read_Area, data);
+void rs485_update_textarea_cb(lv_timer_t* timer) {
+  // If the RS485_Clear flag is set, clear the data buffer
+  if (RS485_Clear) {
+    memset(data, 0, sizeof(data)); // Clear the data buffer
+    RS485_Clear = false;           // Reset the flag
+  }
+
+  // Update the text area with the received data
+  lv_textarea_set_text(ui_RS485_Read_Area, data);
 }
 
 /**
@@ -36,51 +39,49 @@ void rs485_update_textarea_cb(lv_timer_t *timer) {
  * This function is responsible for initializing UART communication for RS485,
  * reading incoming data, and updating the UI with the received data. The data is
  * appended to a global buffer and displayed in a text area on the screen.
- * 
+ *
  * It also periodically checks if the RS485_Clear flag is set, in which case it
- * clears the data buffer and updates the UI.
+ * clears the data buffer and updates
+ * the UI. Incoming messages larger than
+ * RS485_TEMP_BUF_SIZE - 1 bytes are truncated to fit the temporary buffer.
  *
  * @param arg Pointer to the argument passed to the task (unused).
  * @return None
  */
-void rs485_task(void *arg)
-{
-    // Initialize UART communication for RS485 with specified TX, RX pins and baud rate
-    DEV_UART_Init(ECHO_TEST_TXD, ECHO_TEST_RXD, RS485_BaudRate);
+void rs485_task(void* arg) {
+  // Initialize UART communication for RS485 with specified TX, RX pins and baud rate
+  DEV_UART_Init(ECHO_TEST_TXD, ECHO_TEST_RXD, RS485_BaudRate);
 
-    while (1)
-    {
-        // Get the number of bytes available in the UART receive buffer
-        int len = UART_Get_Date_Len();
-        if (len > 0)
-        {
-            // Clear the current read buffer to store new data
-            char temp_buf[len + 1];  // Temporary buffer for storing the received data
-            memset(temp_buf, 0, sizeof(temp_buf));
-            
-            // Read the data from UART into the buffer
-            UART_Read_Byte((uint8_t *)temp_buf, len);
-            temp_buf[len] = '\0';  // Null-terminate the received data
+  while (1) {
+    // Get the number of bytes available in the UART receive buffer
+    int len = UART_Get_Date_Len();
+    if (len > 0) {
+      char temp_buf[RS485_TEMP_BUF_SIZE] = {0}; // Temporary buffer for received data
+      if (len >= RS485_TEMP_BUF_SIZE) {
+        ESP_LOGW(TAG, "UART message too long (%d bytes), truncating to %d", len, RS485_TEMP_BUF_SIZE - 1);
+        len = RS485_TEMP_BUF_SIZE - 1;
+      }
 
-            // Append the new data to the global buffer (if you need to save all data)
-            strncat(data, temp_buf, sizeof(data) - strlen(data) - 1);   
-            
-            // Log the received data
-            ESP_LOGI(TAG, "UART_Read_Byte:%s", data);
+      UART_Read_Byte((uint8_t*)temp_buf, len);
+      temp_buf[len] = '\0'; // Null-terminate the received data
 
-            // Create a timer to update the text area every 100ms
-            lv_timer_t *t = lv_timer_create(rs485_update_textarea_cb, 100, NULL); 
-            lv_timer_set_repeat_count(t, 1);
-        }  
-        
-        // If the RS485_Clear flag is set, clear the data buffer and update the UI
-        if (RS485_Clear)
-        {
-            lv_timer_t *t = lv_timer_create(rs485_update_textarea_cb, 100, NULL); // Update the UI every 100ms
-            lv_timer_set_repeat_count(t, 1);
-        }
-        
-        // Delay for 10ms before checking again
-        vTaskDelay(10);
+      if (strlcat(data, temp_buf, sizeof(data)) >= sizeof(data)) {
+        ESP_LOGW(TAG, "RS485 buffer truncated");
+      }
+
+      ESP_LOGI(TAG, "UART_Read_Byte:%s", data);
+
+      lv_timer_t* t = lv_timer_create(rs485_update_textarea_cb, 100, NULL);
+      lv_timer_set_repeat_count(t, 1);
     }
+
+    // If the RS485_Clear flag is set, clear the data buffer and update the UI
+    if (RS485_Clear) {
+      lv_timer_t* t = lv_timer_create(rs485_update_textarea_cb, 100, NULL); // Update the UI every 100ms
+      lv_timer_set_repeat_count(t, 1);
+    }
+
+    // Delay for 10ms before checking again
+    vTaskDelay(10);
+  }
 }


### PR DESCRIPTION
## Summary
- limit RS485 temp buffer to 256 bytes and guard against oversize messages
- switch RS485 and CAN concatenation to strlcat for safe appends

## Testing
- `bash scripts/checks.sh` (fails: No such file or directory)
- `pre-commit run --files main/user/rs485/rs485.c main/user/can/can.c` (fails: asked for GitHub credentials)


------
https://chatgpt.com/codex/tasks/task_e_689c4558ae6c83238e10aacff4d96716