### PR TITLE
rgb_lcd_port: add shared window buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ The connection between ESP Board and the LCD is as follows:
 
 * Demonstrates an LVGL slider to control LED brightness.
 
+### Static crop buffer
+
+`waveshare_rgb_lcd_display_window` réutilise un tampon RGB565 préalloué
+(`RGB_LCD_WINDOW_BUF_SIZE`, ≈1,2 Mio pour 1024×600) afin d'éviter les
+allocations dynamiques à chaque appel.
+
 ### Configure the Project
 
 ### Build and Flash
@@ -109,4 +115,3 @@ idf.py build
 idf.py -C tests/smoke set-target esp32s3
 idf.py -C tests/smoke build
 ```
-

--- a/components/rgb_lcd_port/rgb_lcd_port.c
+++ b/components/rgb_lcd_port/rgb_lcd_port.c
@@ -14,22 +14,30 @@
 #include "rgb_lcd_port.h"
 #include "lvgl_port.h"
 #include <string.h>
-#include <stdlib.h>
 
-static const char *TAG = "rgb_lcd_port";
+static const char* TAG = "rgb_lcd_port";
+
+/**
+ * @brief Shared RGB565 crop buffer.
+ *
+ * Size is fixed to hold a full-screen frame:
+ * `EXAMPLE_LCD_H_RES * EXAMPLE_LCD_V_RES * 2` bytes (~1.2 MiB for 1024×600).
+ * Allocated once and reused by `waveshare_rgb_lcd_display_window` to avoid
+ * per-call heap usage. This buffer is not thread-safe.
+ */
+#define RGB_LCD_WINDOW_BUF_SIZE (EXAMPLE_LCD_H_RES * EXAMPLE_LCD_V_RES * 2)
+static uint8_t* window_buf = NULL;
 
 // Handle for the RGB LCD panel
 static esp_lcd_panel_handle_t panel_handle = NULL;
 
 // VSYNC event callback function
-IRAM_ATTR static bool rgb_lcd_on_vsync_event(esp_lcd_panel_handle_t panel,
-                                             const esp_lcd_rgb_panel_event_data_t *edata,
-                                             void *user_ctx)
-{
-    (void)panel;
-    (void)edata;
-    (void)user_ctx;
-    return lvgl_port_notify_rgb_vsync();
+IRAM_ATTR static bool rgb_lcd_on_vsync_event(esp_lcd_panel_handle_t panel, const esp_lcd_rgb_panel_event_data_t* edata,
+                                             void* user_ctx) {
+  (void)panel;
+  (void)edata;
+  (void)user_ctx;
+  return lvgl_port_notify_rgb_vsync();
 }
 
 /**
@@ -43,83 +51,102 @@ IRAM_ATTR static bool rgb_lcd_on_vsync_event(esp_lcd_panel_handle_t panel,
  *    - esp_lcd_panel_handle_t: panel handle on success
  *    - NULL: Initialization failed.
  */
-esp_lcd_panel_handle_t waveshare_esp32_s3_rgb_lcd_init(void)
-{
-    ESP_LOGI(TAG, "Install RGB LCD panel driver");
+esp_lcd_panel_handle_t waveshare_esp32_s3_rgb_lcd_init(void) {
+  ESP_LOGI(TAG, "Install RGB LCD panel driver");
 
-    /* Typical polarities for ST7262 1024x600 TTL panel:
-     *  - DE: active HIGH
-     *  - HSYNC/VSYNC: active HIGH (idle LOW)
-     *  - PCLK: sample on rising edge (active_neg = 0)
-     * If your glass requires the opposite, only change the flags below.
-     */
-    esp_lcd_rgb_panel_config_t panel_config = {
-        .clk_src = LCD_CLK_SRC_DEFAULT,
-        .timings = {
-            .pclk_hz = EXAMPLE_LCD_PIXEL_CLOCK_HZ,
-            .h_res = EXAMPLE_LCD_H_RES,
-            .v_res = EXAMPLE_LCD_V_RES,
-            .hsync_pulse_width = 162,
-            .hsync_back_porch  = 152,
-            .hsync_front_porch = 48,
-            .vsync_pulse_width = 45,
-            .vsync_back_porch  = 13,
-            .vsync_front_porch = 3,
-            .flags = {
-                .pclk_active_neg = 0,   // sample on rising edge (fixable here if needed)
-                .hsync_idle_low  = 1,   // HSYNC idle LOW → active HIGH
-                .vsync_idle_low  = 1,   // VSYNC idle LOW → active HIGH
-                .de_idle_high    = 1,   // DE active HIGH
-                .pclk_idle_high  = 0,
-            },
-        },
-        .data_width = EXAMPLE_RGB_DATA_WIDTH,
-        .bits_per_pixel = EXAMPLE_RGB_BIT_PER_PIXEL,
-        .num_fbs = EXAMPLE_LCD_RGB_BUFFER_NUMS,
-        .bounce_buffer_size_px = EXAMPLE_RGB_BOUNCE_BUFFER_SIZE,
-        .sram_trans_align = 4,
-        .psram_trans_align = 64,
-        .hsync_gpio_num = EXAMPLE_LCD_IO_RGB_HSYNC,
-        .vsync_gpio_num = EXAMPLE_LCD_IO_RGB_VSYNC,
-        .de_gpio_num    = EXAMPLE_LCD_IO_RGB_DE,
-        .pclk_gpio_num  = EXAMPLE_LCD_IO_RGB_PCLK,
-        .disp_gpio_num  = EXAMPLE_LCD_IO_RGB_DISP,
-        .data_gpio_nums = {
-            EXAMPLE_LCD_IO_RGB_DATA0,  EXAMPLE_LCD_IO_RGB_DATA1,
-            EXAMPLE_LCD_IO_RGB_DATA2,  EXAMPLE_LCD_IO_RGB_DATA3,
-            EXAMPLE_LCD_IO_RGB_DATA4,  EXAMPLE_LCD_IO_RGB_DATA5,
-            EXAMPLE_LCD_IO_RGB_DATA6,  EXAMPLE_LCD_IO_RGB_DATA7,
-            EXAMPLE_LCD_IO_RGB_DATA8,  EXAMPLE_LCD_IO_RGB_DATA9,
-            EXAMPLE_LCD_IO_RGB_DATA10, EXAMPLE_LCD_IO_RGB_DATA11,
-            EXAMPLE_LCD_IO_RGB_DATA12, EXAMPLE_LCD_IO_RGB_DATA13,
-            EXAMPLE_LCD_IO_RGB_DATA14, EXAMPLE_LCD_IO_RGB_DATA15,
-        },
-        .flags = {
-            .fb_in_psram = 1,
-        },
-    };
+  /* Typical polarities for ST7262 1024x600 TTL panel:
+   *  - DE: active HIGH
+   *  - HSYNC/VSYNC: active HIGH (idle LOW)
+   *  - PCLK: sample on rising edge (active_neg = 0)
+   * If your glass requires the opposite, only change the flags below.
+   */
+  esp_lcd_rgb_panel_config_t panel_config = {
+      .clk_src = LCD_CLK_SRC_DEFAULT,
+      .timings =
+          {
+              .pclk_hz = EXAMPLE_LCD_PIXEL_CLOCK_HZ,
+              .h_res = EXAMPLE_LCD_H_RES,
+              .v_res = EXAMPLE_LCD_V_RES,
+              .hsync_pulse_width = 162,
+              .hsync_back_porch = 152,
+              .hsync_front_porch = 48,
+              .vsync_pulse_width = 45,
+              .vsync_back_porch = 13,
+              .vsync_front_porch = 3,
+              .flags =
+                  {
+                      .pclk_active_neg = 0, // sample on rising edge (fixable here if needed)
+                      .hsync_idle_low = 1,  // HSYNC idle LOW → active HIGH
+                      .vsync_idle_low = 1,  // VSYNC idle LOW → active HIGH
+                      .de_idle_high = 1,    // DE active HIGH
+                      .pclk_idle_high = 0,
+                  },
+          },
+      .data_width = EXAMPLE_RGB_DATA_WIDTH,
+      .bits_per_pixel = EXAMPLE_RGB_BIT_PER_PIXEL,
+      .num_fbs = EXAMPLE_LCD_RGB_BUFFER_NUMS,
+      .bounce_buffer_size_px = EXAMPLE_RGB_BOUNCE_BUFFER_SIZE,
+      .sram_trans_align = 4,
+      .psram_trans_align = 64,
+      .hsync_gpio_num = EXAMPLE_LCD_IO_RGB_HSYNC,
+      .vsync_gpio_num = EXAMPLE_LCD_IO_RGB_VSYNC,
+      .de_gpio_num = EXAMPLE_LCD_IO_RGB_DE,
+      .pclk_gpio_num = EXAMPLE_LCD_IO_RGB_PCLK,
+      .disp_gpio_num = EXAMPLE_LCD_IO_RGB_DISP,
+      .data_gpio_nums =
+          {
+              EXAMPLE_LCD_IO_RGB_DATA0,
+              EXAMPLE_LCD_IO_RGB_DATA1,
+              EXAMPLE_LCD_IO_RGB_DATA2,
+              EXAMPLE_LCD_IO_RGB_DATA3,
+              EXAMPLE_LCD_IO_RGB_DATA4,
+              EXAMPLE_LCD_IO_RGB_DATA5,
+              EXAMPLE_LCD_IO_RGB_DATA6,
+              EXAMPLE_LCD_IO_RGB_DATA7,
+              EXAMPLE_LCD_IO_RGB_DATA8,
+              EXAMPLE_LCD_IO_RGB_DATA9,
+              EXAMPLE_LCD_IO_RGB_DATA10,
+              EXAMPLE_LCD_IO_RGB_DATA11,
+              EXAMPLE_LCD_IO_RGB_DATA12,
+              EXAMPLE_LCD_IO_RGB_DATA13,
+              EXAMPLE_LCD_IO_RGB_DATA14,
+              EXAMPLE_LCD_IO_RGB_DATA15,
+          },
+      .flags =
+          {
+              .fb_in_psram = 1,
+          },
+  };
 
-    if (esp_lcd_new_rgb_panel(&panel_config, &panel_handle) != ESP_OK) {
-        ESP_LOGE(TAG, "esp_lcd_new_rgb_panel failed");
-        return NULL;
+  if (esp_lcd_new_rgb_panel(&panel_config, &panel_handle) != ESP_OK) {
+    ESP_LOGE(TAG, "esp_lcd_new_rgb_panel failed");
+    return NULL;
+  }
+
+  ESP_LOGI(TAG, "Initialize RGB LCD panel");
+  if (esp_lcd_panel_init(panel_handle) != ESP_OK) {
+    ESP_LOGE(TAG, "esp_lcd_panel_init failed");
+    return NULL;
+  }
+
+  esp_lcd_rgb_panel_event_callbacks_t cbs = {
+#if EXAMPLE_RGB_BOUNCE_BUFFER_SIZE > 0
+      .on_bounce_frame_finish = rgb_lcd_on_vsync_event,
+#else
+      .on_vsync = rgb_lcd_on_vsync_event,
+#endif
+  };
+  (void)esp_lcd_rgb_panel_register_event_callbacks(panel_handle, &cbs, NULL);
+
+  if (!window_buf) {
+    window_buf = heap_caps_malloc(RGB_LCD_WINDOW_BUF_SIZE, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (!window_buf) {
+      ESP_LOGE(TAG, "Failed to allocate window buffer (%d bytes)", RGB_LCD_WINDOW_BUF_SIZE);
+      return NULL;
     }
+  }
 
-    ESP_LOGI(TAG, "Initialize RGB LCD panel");
-    if (esp_lcd_panel_init(panel_handle) != ESP_OK) {
-        ESP_LOGE(TAG, "esp_lcd_panel_init failed");
-        return NULL;
-    }
-
-    esp_lcd_rgb_panel_event_callbacks_t cbs = {
-    #if EXAMPLE_RGB_BOUNCE_BUFFER_SIZE > 0
-        .on_bounce_frame_finish = rgb_lcd_on_vsync_event,
-    #else
-        .on_vsync = rgb_lcd_on_vsync_event,
-    #endif
-    };
-    (void)esp_lcd_rgb_panel_register_event_callbacks(panel_handle, &cbs, NULL);
-
-    return panel_handle;
+  return panel_handle;
 }
 
 /**
@@ -131,71 +158,58 @@ esp_lcd_panel_handle_t waveshare_esp32_s3_rgb_lcd_init(void)
  * @param Yend   Ending Y coordinate (exclusive, absolute).
  * @param Image  Pointer to the image data buffer for full LCD resolution.
  */
-void waveshare_rgb_lcd_display_window(int16_t Xstart, int16_t Ystart,
-                                      int16_t Xend, int16_t Yend, uint8_t *Image)
-{
-    if (Xstart < 0) Xstart = 0;
-    if (Ystart < 0) Ystart = 0;
-    if (Xend > EXAMPLE_LCD_H_RES) Xend = EXAMPLE_LCD_H_RES;
-    if (Yend > EXAMPLE_LCD_V_RES) Yend = EXAMPLE_LCD_V_RES;
-    if (Xend <= Xstart || Yend <= Ystart) return;
+void waveshare_rgb_lcd_display_window(int16_t Xstart, int16_t Ystart, int16_t Xend, int16_t Yend, uint8_t* Image) {
+  if (Xstart < 0)
+    Xstart = 0;
+  if (Ystart < 0)
+    Ystart = 0;
+  if (Xend > EXAMPLE_LCD_H_RES)
+    Xend = EXAMPLE_LCD_H_RES;
+  if (Yend > EXAMPLE_LCD_V_RES)
+    Yend = EXAMPLE_LCD_V_RES;
+  if (Xend <= Xstart || Yend <= Ystart)
+    return;
 
-    const int crop_width  = (int)(Xend - Xstart);
-    const int crop_height = (int)(Yend - Ystart);
+  const int crop_width = (int)(Xend - Xstart);
+  const int crop_height = (int)(Yend - Ystart);
 
-    // Allocate temporary crop buffer (2 bytes per pixel, RGB565)
-    uint8_t *dst_data = (uint8_t *)malloc((size_t)crop_width * crop_height * 2);
-    if (!dst_data) {
-        ESP_LOGE(TAG, "Failed to allocate crop buffer (%d x %d)", crop_width, crop_height);
-        return;
-    }
+  size_t needed = (size_t)crop_width * crop_height * 2; // RGB565
+  if (!window_buf || needed > RGB_LCD_WINDOW_BUF_SIZE) {
+    ESP_LOGE(TAG, "Crop buffer too small (%zu > %d)", needed, RGB_LCD_WINDOW_BUF_SIZE);
+    return;
+  }
 
-    // Copy rows
-    for (int y = 0; y < crop_height; y++) {
-        const uint8_t *src_row = Image + ((size_t)(Ystart + y) * EXAMPLE_LCD_H_RES + Xstart) * 2;
-        uint8_t *dst_row       = dst_data + (size_t)y * crop_width * 2;
-        memcpy(dst_row, src_row, (size_t)crop_width * 2);
-    }
+  // Copy rows into shared buffer
+  for (int y = 0; y < crop_height; y++) {
+    const uint8_t* src_row = Image + ((size_t)(Ystart + y) * EXAMPLE_LCD_H_RES + Xstart) * 2;
+    uint8_t* dst_row = window_buf + (size_t)y * crop_width * 2;
+    memcpy(dst_row, src_row, (size_t)crop_width * 2);
+  }
 
-    esp_lcd_panel_draw_bitmap(panel_handle, Xstart, Ystart, Xend, Yend, dst_data);
-    free(dst_data);
+  esp_lcd_panel_draw_bitmap(panel_handle, Xstart, Ystart, Xend, Yend, window_buf);
 }
 
 /**
  * @brief Display a full-screen image on the RGB LCD.
  */
-void waveshare_rgb_lcd_display(uint8_t *Image)
-{
-    esp_lcd_panel_draw_bitmap(panel_handle, 0, 0, EXAMPLE_LCD_H_RES, EXAMPLE_LCD_V_RES, Image);
+void waveshare_rgb_lcd_display(uint8_t* Image) {
+  esp_lcd_panel_draw_bitmap(panel_handle, 0, 0, EXAMPLE_LCD_H_RES, EXAMPLE_LCD_V_RES, Image);
 }
 
-void waveshare_get_frame_buffer(void **buf1, void **buf2)
-{
-    ESP_ERROR_CHECK(esp_lcd_rgb_panel_get_frame_buffer(panel_handle, 2, buf1, buf2));
+void waveshare_get_frame_buffer(void** buf1, void** buf2) {
+  ESP_ERROR_CHECK(esp_lcd_rgb_panel_get_frame_buffer(panel_handle, 2, buf1, buf2));
 }
 
-void waveshare_rgb_lcd_set_pclk(uint32_t freq_hz)
-{
-    esp_lcd_rgb_panel_set_pclk(panel_handle, freq_hz);
-}
+void waveshare_rgb_lcd_set_pclk(uint32_t freq_hz) { esp_lcd_rgb_panel_set_pclk(panel_handle, freq_hz); }
 
-void waveshare_rgb_lcd_restart(void)
-{
-    esp_lcd_rgb_panel_restart(panel_handle);
-}
+void waveshare_rgb_lcd_restart(void) { esp_lcd_rgb_panel_restart(panel_handle); }
 
 /**
  * @brief Turn on the RGB LCD screen backlight.
  */
-void waveshare_rgb_lcd_bl_on(void)
-{
-    IO_EXTENSION_Output(IO_EXTENSION_IO_2, 1);
-}
+void waveshare_rgb_lcd_bl_on(void) { IO_EXTENSION_Output(IO_EXTENSION_IO_2, 1); }
 
 /**
  * @brief Turn off the RGB LCD screen backlight.
  */
-void waveshare_rgb_lcd_bl_off(void)
-{
-    IO_EXTENSION_Output(IO_EXTENSION_IO_2, 0);
-}
+void waveshare_rgb_lcd_bl_off(void) { IO_EXTENSION_Output(IO_EXTENSION_IO_2, 0); }

--- a/components/rgb_lcd_port/rgb_lcd_port.h
+++ b/components/rgb_lcd_port/rgb_lcd_port.h
@@ -15,13 +15,13 @@
 
 #pragma once
 
-#include "esp_log.h"
 #include "esp_heap_caps.h"
-#include "io_extension.h"
-#include "freertos/FreeRTOS.h"
-#include "freertos/task.h"
 #include "esp_lcd_panel_ops.h"
 #include "esp_lcd_panel_rgb.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "io_extension.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////// Please update the following configuration according to your LCD spec //////////////////////////////
@@ -30,60 +30,60 @@
 /**
  * @brief LCD Resolution and Timing
  */
-#define EXAMPLE_LCD_H_RES               (1024)   ///< Horizontal resolution in pixels
-#define EXAMPLE_LCD_V_RES               (600)    ///< Vertical resolution in pixels
-#define EXAMPLE_LCD_PIXEL_CLOCK_HZ      (30850000U) ///< Pixel clock frequency in Hz (integer constant)
+#define EXAMPLE_LCD_H_RES (1024)               ///< Horizontal resolution in pixels
+#define EXAMPLE_LCD_V_RES (600)                ///< Vertical resolution in pixels
+#define EXAMPLE_LCD_PIXEL_CLOCK_HZ (30850000U) ///< Pixel clock frequency in Hz (integer constant)
 
 /**
  * @brief Color and Pixel Configuration
  */
-#define EXAMPLE_LCD_BIT_PER_PIXEL       (16)   ///< Bits per pixel (color depth)
-#define EXAMPLE_RGB_BIT_PER_PIXEL       (16)   ///< RGB interface color depth
-#define EXAMPLE_RGB_DATA_WIDTH          (16)   ///< Data width for RGB interface
-#define EXAMPLE_LCD_RGB_BUFFER_NUMS     (2)    ///< Number of frame buffers for double buffering
-#define EXAMPLE_RGB_BOUNCE_BUFFER_SIZE  (EXAMPLE_LCD_H_RES * 10) ///< Size of bounce buffer for RGB data
+#define EXAMPLE_LCD_BIT_PER_PIXEL (16)                          ///< Bits per pixel (color depth)
+#define EXAMPLE_RGB_BIT_PER_PIXEL (16)                          ///< RGB interface color depth
+#define EXAMPLE_RGB_DATA_WIDTH (16)                             ///< Data width for RGB interface
+#define EXAMPLE_LCD_RGB_BUFFER_NUMS (2)                         ///< Number of frame buffers for double buffering
+#define EXAMPLE_RGB_BOUNCE_BUFFER_SIZE (EXAMPLE_LCD_H_RES * 10) ///< Size of bounce buffer for RGB data
 
 /**
  * @brief GPIO Pins for RGB LCD Signals
  */
-#define EXAMPLE_LCD_IO_RGB_DISP         (-1)           ///< DISP signal, -1 if not used
-#define EXAMPLE_LCD_IO_RGB_VSYNC        (GPIO_NUM_3)   ///< Vertical sync signal
-#define EXAMPLE_LCD_IO_RGB_HSYNC        (GPIO_NUM_46)  ///< Horizontal sync signal
-#define EXAMPLE_LCD_IO_RGB_DE           (GPIO_NUM_5)   ///< Data enable signal
-#define EXAMPLE_LCD_IO_RGB_PCLK         (GPIO_NUM_7)   ///< Pixel clock signal
+#define EXAMPLE_LCD_IO_RGB_DISP (-1)           ///< DISP signal, -1 if not used
+#define EXAMPLE_LCD_IO_RGB_VSYNC (GPIO_NUM_3)  ///< Vertical sync signal
+#define EXAMPLE_LCD_IO_RGB_HSYNC (GPIO_NUM_46) ///< Horizontal sync signal
+#define EXAMPLE_LCD_IO_RGB_DE (GPIO_NUM_5)     ///< Data enable signal
+#define EXAMPLE_LCD_IO_RGB_PCLK (GPIO_NUM_7)   ///< Pixel clock signal
 
 /**
  * @brief GPIO Pins for RGB Data Signals
  */
 /* Blue data (B3..B7) */
-#define EXAMPLE_LCD_IO_RGB_DATA0        (GPIO_NUM_14) ///< B3
-#define EXAMPLE_LCD_IO_RGB_DATA1        (GPIO_NUM_38) ///< B4
-#define EXAMPLE_LCD_IO_RGB_DATA2        (GPIO_NUM_18) ///< B5
-#define EXAMPLE_LCD_IO_RGB_DATA3        (GPIO_NUM_17) ///< B6
-#define EXAMPLE_LCD_IO_RGB_DATA4        (GPIO_NUM_10) ///< B7
+#define EXAMPLE_LCD_IO_RGB_DATA0 (GPIO_NUM_14) ///< B3
+#define EXAMPLE_LCD_IO_RGB_DATA1 (GPIO_NUM_38) ///< B4
+#define EXAMPLE_LCD_IO_RGB_DATA2 (GPIO_NUM_18) ///< B5
+#define EXAMPLE_LCD_IO_RGB_DATA3 (GPIO_NUM_17) ///< B6
+#define EXAMPLE_LCD_IO_RGB_DATA4 (GPIO_NUM_10) ///< B7
 
 /* Green data (G2..G7) */
-#define EXAMPLE_LCD_IO_RGB_DATA5        (GPIO_NUM_39) ///< G2
-#define EXAMPLE_LCD_IO_RGB_DATA6        (GPIO_NUM_0)  ///< G3
-#define EXAMPLE_LCD_IO_RGB_DATA7        (GPIO_NUM_45) ///< G4
-#define EXAMPLE_LCD_IO_RGB_DATA8        (GPIO_NUM_48) ///< G5
-#define EXAMPLE_LCD_IO_RGB_DATA9        (GPIO_NUM_47) ///< G6
-#define EXAMPLE_LCD_IO_RGB_DATA10       (GPIO_NUM_21) ///< G7
+#define EXAMPLE_LCD_IO_RGB_DATA5 (GPIO_NUM_39)  ///< G2
+#define EXAMPLE_LCD_IO_RGB_DATA6 (GPIO_NUM_0)   ///< G3
+#define EXAMPLE_LCD_IO_RGB_DATA7 (GPIO_NUM_45)  ///< G4
+#define EXAMPLE_LCD_IO_RGB_DATA8 (GPIO_NUM_48)  ///< G5
+#define EXAMPLE_LCD_IO_RGB_DATA9 (GPIO_NUM_47)  ///< G6
+#define EXAMPLE_LCD_IO_RGB_DATA10 (GPIO_NUM_21) ///< G7
 
 /* Red data (R3..R7) */
-#define EXAMPLE_LCD_IO_RGB_DATA11       (GPIO_NUM_1)  ///< R3
-#define EXAMPLE_LCD_IO_RGB_DATA12       (GPIO_NUM_2)  ///< R4
-#define EXAMPLE_LCD_IO_RGB_DATA13       (GPIO_NUM_42) ///< R5
-#define EXAMPLE_LCD_IO_RGB_DATA14       (GPIO_NUM_41) ///< R6
-#define EXAMPLE_LCD_IO_RGB_DATA15       (GPIO_NUM_40) ///< R7
+#define EXAMPLE_LCD_IO_RGB_DATA11 (GPIO_NUM_1)  ///< R3
+#define EXAMPLE_LCD_IO_RGB_DATA12 (GPIO_NUM_2)  ///< R4
+#define EXAMPLE_LCD_IO_RGB_DATA13 (GPIO_NUM_42) ///< R5
+#define EXAMPLE_LCD_IO_RGB_DATA14 (GPIO_NUM_41) ///< R6
+#define EXAMPLE_LCD_IO_RGB_DATA15 (GPIO_NUM_40) ///< R7
 
 /**
  * @brief Reset and Backlight Configuration
  */
-#define EXAMPLE_LCD_IO_RST              (-1)   ///< Reset pin, -1 if not used
-#define EXAMPLE_PIN_NUM_BK_LIGHT        (-1)   ///< Backlight pin, -1 if not used
-#define EXAMPLE_LCD_BK_LIGHT_ON_LEVEL   (1)    ///< Logic level to turn on backlight
-#define EXAMPLE_LCD_BK_LIGHT_OFF_LEVEL  (!EXAMPLE_LCD_BK_LIGHT_ON_LEVEL) ///< Logic level to turn off backlight
+#define EXAMPLE_LCD_IO_RST (-1)                                         ///< Reset pin, -1 if not used
+#define EXAMPLE_PIN_NUM_BK_LIGHT (-1)                                   ///< Backlight pin, -1 if not used
+#define EXAMPLE_LCD_BK_LIGHT_ON_LEVEL (1)                               ///< Logic level to turn on backlight
+#define EXAMPLE_LCD_BK_LIGHT_OFF_LEVEL (!EXAMPLE_LCD_BK_LIGHT_ON_LEVEL) ///< Logic level to turn off backlight
 
 /**
  * @brief Function Declarations
@@ -98,18 +98,21 @@ void waveshare_rgb_lcd_bl_off(void);
 
 /**
  * @brief Display a rectangular region of an image on the RGB LCD.
+ *
+ * Utilise un tampon RGB565 statique de taille
+ * `EXAMPLE_LCD_H_RES * EXAMPLE_LCD_V_RES * 2` octets partagé entre les appels.
  */
-void waveshare_rgb_lcd_display_window(int16_t Xstart, int16_t Ystart, int16_t Xend, int16_t Yend, uint8_t *Image);
+void waveshare_rgb_lcd_display_window(int16_t Xstart, int16_t Ystart, int16_t Xend, int16_t Yend, uint8_t* Image);
 
 /**
  * @brief Display a full-frame image on the RGB LCD.
  */
-void waveshare_rgb_lcd_display(uint8_t *Image);
+void waveshare_rgb_lcd_display(uint8_t* Image);
 
 /**
  * @brief Retrieve pointers to the frame buffers for double buffering.
  */
-void waveshare_get_frame_buffer(void **buf1, void **buf2);
+void waveshare_get_frame_buffer(void** buf1, void** buf2);
 void waveshare_rgb_lcd_set_pclk(uint32_t freq_hz);
 void waveshare_rgb_lcd_restart(void);
 


### PR DESCRIPTION
## Summary
- add global RGB565 window buffer and reuse it instead of malloc/free
- document buffer size and usage in code and README

## Testing
- `bash scripts/checks.sh` (missing script)
- `bash scripts/setup_codex_env.sh` (failed: curl 404)
- `make build` (failed: cannot open /export.sh)


------
https://chatgpt.com/codex/tasks/task_e_689c5596fadc832396de62eb3e3663b3