### PR TITLE
tests: add rs485 loopback and wifi ap/sta simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,14 +148,14 @@ Des scénarios de test minimaux sont fournis sous `tests/` :
 # LVGL : initialisation de la pile graphique
 idf.py -C tests/smoke build
 
-# Wi‑Fi : initialisation du driver
-idf.py -C tests/wifi build
+# Wi‑Fi : simulation AP/STA avec EventGroup
+idf.py -C tests/wifi flash monitor   # attend "Wi-Fi AP/STA simulation succeeded"
 
-# RS485 : vérification de l’UART half‑duplex
-idf.py -C tests/rs485 build
+# RS485 : loopback half‑duplex
+idf.py -C tests/rs485 flash monitor  # attend "RS485 loopback OK"
 
 # CAN : tests du contrôleur CAN intégré
 idf.py -C tests/can build
 ```
 
-Ajouter `-p "${ESPPORT}" flash` pour flasher un test sur la carte.
+Adapter `-p "${ESPPORT}"` si nécessaire pour flasher la carte.

--- a/tests/rs485/main/test_rs485.c
+++ b/tests/rs485/main/test_rs485.c
@@ -1,5 +1,6 @@
 #include "driver/uart.h"
 #include "esp_log.h"
+#include <string.h>
 
 static const char *TAG = "RS485_TEST";
 
@@ -14,6 +15,19 @@ void app_main(void) {
     ESP_ERROR_CHECK(uart_param_config(UART_NUM_1, &uart_config));
     ESP_ERROR_CHECK(uart_driver_install(UART_NUM_1, 256, 0, 0, NULL, 0));
     ESP_ERROR_CHECK(uart_set_mode(UART_NUM_1, UART_MODE_RS485_HALF_DUPLEX));
-    ESP_LOGI(TAG, "RS485 init test OK");
+    ESP_ERROR_CHECK(uart_set_loop_back(UART_NUM_1, true));
+
+    const char *test_str = "rs485 loop";
+    uint8_t rx_buf[32] = {0};
+    ESP_ERROR_CHECK(uart_write_bytes(UART_NUM_1, test_str, strlen(test_str)));
+    ESP_ERROR_CHECK(uart_wait_tx_done(UART_NUM_1, pdMS_TO_TICKS(100)));
+    int len = uart_read_bytes(UART_NUM_1, rx_buf, sizeof(rx_buf), pdMS_TO_TICKS(100));
+
+    if (len == (int)strlen(test_str) && memcmp(rx_buf, test_str, len) == 0) {
+        ESP_LOGI(TAG, "RS485 loopback OK");
+    } else {
+        ESP_LOGE(TAG, "RS485 loopback failed");
+    }
+
     uart_driver_delete(UART_NUM_1);
 }

--- a/tests/wifi/main/test_wifi.c
+++ b/tests/wifi/main/test_wifi.c
@@ -3,14 +3,56 @@
 #include "esp_netif.h"
 #include "esp_wifi.h"
 #include "nvs_flash.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
 
 static const char *TAG = "WIFI_TEST";
+
+#define WIFI_AP_STARTED_BIT   BIT0
+#define WIFI_STA_CONNECTED_BIT BIT1
+#define WIFI_STA_GOT_IP_BIT    BIT2
+
+static EventGroupHandle_t wifi_event_group;
+
+static void wifi_event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data) {
+    if (event_base == WIFI_EVENT) {
+        if (event_id == WIFI_EVENT_AP_START) {
+            xEventGroupSetBits(wifi_event_group, WIFI_AP_STARTED_BIT);
+        } else if (event_id == WIFI_EVENT_STA_CONNECTED) {
+            xEventGroupSetBits(wifi_event_group, WIFI_STA_CONNECTED_BIT);
+        }
+    } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
+        xEventGroupSetBits(wifi_event_group, WIFI_STA_GOT_IP_BIT);
+    }
+}
 
 void app_main(void) {
     ESP_ERROR_CHECK(nvs_flash_init());
     ESP_ERROR_CHECK(esp_netif_init());
     ESP_ERROR_CHECK(esp_event_loop_create_default());
+    wifi_event_group = xEventGroupCreate();
+
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
     ESP_ERROR_CHECK(esp_wifi_init(&cfg));
-    ESP_LOGI(TAG, "Wi-Fi init test OK");
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &wifi_event_handler, NULL, NULL));
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(IP_EVENT, ESP_EVENT_ANY_ID, &wifi_event_handler, NULL, NULL));
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_APSTA));
+    ESP_ERROR_CHECK(esp_wifi_start());
+
+    ESP_ERROR_CHECK(esp_event_post(WIFI_EVENT, WIFI_EVENT_AP_START, NULL, 0, portMAX_DELAY));
+    ESP_ERROR_CHECK(esp_event_post(WIFI_EVENT, WIFI_EVENT_STA_CONNECTED, NULL, 0, portMAX_DELAY));
+    ESP_ERROR_CHECK(esp_event_post(IP_EVENT, IP_EVENT_STA_GOT_IP, NULL, 0, portMAX_DELAY));
+
+    EventBits_t bits = xEventGroupWaitBits(wifi_event_group,
+                                           WIFI_AP_STARTED_BIT | WIFI_STA_CONNECTED_BIT | WIFI_STA_GOT_IP_BIT,
+                                           pdTRUE, pdTRUE, pdMS_TO_TICKS(1000));
+
+    if ((bits & (WIFI_AP_STARTED_BIT | WIFI_STA_CONNECTED_BIT | WIFI_STA_GOT_IP_BIT)) ==
+        (WIFI_AP_STARTED_BIT | WIFI_STA_CONNECTED_BIT | WIFI_STA_GOT_IP_BIT)) {
+        ESP_LOGI(TAG, "Wi-Fi AP/STA simulation succeeded");
+    } else {
+        ESP_LOGE(TAG, "Wi-Fi AP/STA simulation failed");
+    }
+
+    ESP_ERROR_CHECK(esp_wifi_stop());
 }


### PR DESCRIPTION
## Summary
- add RS485 loopback send/receive test
- simulate Wi-Fi AP/STA connection with EventGroup callbacks
- document how to run the new tests

## Testing
- `bash scripts/checks.sh` *(fails: No such file or directory)*
- `idf.py -C tests/rs485 build` *(fails: command not found)*
- `idf.py -C tests/wifi build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689c687f67c083239f0e73fb0bc3d181